### PR TITLE
feat: add engineering standards (ESLint, Prettier, scripts)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,22 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    project: './tsconfig.json',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended-type-checked',
+    'plugin:@typescript-eslint/stylistic-type-checked',
+  ],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+  },
+  ignorePatterns: ['dist', 'node_modules', 'coverage', '*.js', '*.d.ts'],
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,12 @@
+dist/
+node_modules/
+coverage/
+*.d.ts
+*.d.ts.map
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+.env
+.env.*
+*.log
+cache/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/package.json
+++ b/package.json
@@ -1,12 +1,18 @@
 {
   "name": "tritai",
   "version": "0.6.0",
-  "description": "TriTai \u4e09\u624d - \u96f6 Token \u9632\u5e7b\u89c9\u5f15\u64ce\uff0c\u57fa\u4e8e\u592a\u6781\u54f2\u5b66\u7684 AI \u5e7b\u89c9\u68c0\u6d4b\u7cfb\u7edf",
+  "description": "TriTai 三才 - 零 Token 防幻觉引擎，基于太极哲学的 AI 幻觉检测系统",
   "main": "wfgy.js",
   "types": "index.ts",
   "scripts": {
     "build": "tsc --project tsconfig.json",
-    "watch": "tsc --project tsconfig.json --watch",
+    "dev": "tsc --project tsconfig.json --watch",
+    "lint": "eslint . --ext .ts",
+    "lint:fix": "eslint . --ext .ts --fix",
+    "test": "node verify.js",
+    "type-check": "tsc --noEmit",
+    "format": "prettier --write \"**/*.{ts,js,json,md}\"",
+    "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
     "clean": "rm -rf ../../dist/integrations/mcp-client"
   },
   "dependencies": {
@@ -19,6 +25,10 @@
   },
   "devDependencies": {
     "@types/node": "^20.19.39",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "eslint": "^9.0.0",
+    "prettier": "^3.3.0",
     "typescript": "^6.0.3"
   },
   "keywords": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "allowSyntheticDefaultImports": true,
-    "useDefineForClassFields": true
+    "useDefineForClassFields": true,
+    "composite": true
   },
   "include": [
     "*.ts"


### PR DESCRIPTION
## Summary

This PR adds engineering standards compliance to the tritai project:

### Changes Made

1. **ESLint Configuration** - Added `.eslintrc.js` with TypeScript-eslint support
2. **Prettier Configuration** - Added `.prettierrc` and `.prettierignore`
3. **Complete package.json scripts**:
   - `build`: Compile TypeScript
   - `dev`: Watch mode
   - `lint`: Run ESLint
   - `lint:fix`: Auto-fix lint issues
   - `test`: Run tests
   - `type-check`: TypeScript type checking
   - `format`: Format code with Prettier
   - `format:check`: Check formatting
4. **tsconfig.json**: Added `composite: true` for project references

### Standards Compliance

- ✅ TypeScript Strict Mode
- ✅ ESLint Configuration
- ✅ Prettier Configuration  
- ✅ Build Pipeline (package.json scripts)
- ✅ TypeScript Project References (composite)
- ✅ README + CHANGELOG
- ✅ GitHub Actions CI/CD
- ✅ .gitignore

Please review and merge!
